### PR TITLE
Refactored code to send patient matchmaking requests

### DIFF
--- a/core/api/src/main/java/org/phenotips/remote/api/tojson/OutgoingRequestToJSONConverter.java
+++ b/core/api/src/main/java/org/phenotips/remote/api/tojson/OutgoingRequestToJSONConverter.java
@@ -19,10 +19,9 @@
  */
 package org.phenotips.remote.api.tojson;
 
-import org.phenotips.remote.api.OutgoingSearchRequest;
 import net.sf.json.JSONObject;
 
 public interface OutgoingRequestToJSONConverter
 {
-    JSONObject toJSON(OutgoingSearchRequest request, int includedTopGenes);
+    JSONObject toJSON(String patientId, int includedTopGenes);
 }

--- a/core/client/src/main/java/org/phenotips/remote/client/RemoteMatchingService.java
+++ b/core/client/src/main/java/org/phenotips/remote/client/RemoteMatchingService.java
@@ -33,5 +33,7 @@ import net.sf.json.JSONObject;
 @Role
 public interface RemoteMatchingService
 {
-    public JSONObject sendRequest(String patientId, String remoteServerId, boolean async, boolean periodic, int addTopNGenes);
+    public JSONObject getRequest(String patientId, int addTopNGenes);
+
+    public JSONObject sendRequest(String patientId, String remoteServerId, int addTopNGenes);
 }

--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultOutgoingRequestToJSONConverter.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultOutgoingRequestToJSONConverter.java
@@ -21,16 +21,16 @@ package org.phenotips.remote.common.internal.api;
 
 import org.phenotips.data.Patient;
 import org.phenotips.data.PatientRepository;
-import org.phenotips.remote.api.tojson.OutgoingRequestToJSONConverter;
 import org.phenotips.remote.api.ApiConfiguration;
 import org.phenotips.remote.api.ApiViolationException;
-import org.phenotips.remote.api.OutgoingSearchRequest;
+import org.phenotips.remote.api.tojson.OutgoingRequestToJSONConverter;
 import org.phenotips.remote.api.tojson.PatientToJSONConverter;
-import org.phenotips.remote.common.internal.api.DefaultPatientToJSONConverter;
-import org.slf4j.Logger;
+
+import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
-import org.xwiki.bridge.DocumentAccessBridge;
+
+import org.slf4j.Logger;
 
 import net.sf.json.JSONObject;
 
@@ -62,10 +62,8 @@ public class DefaultOutgoingRequestToJSONConverter implements OutgoingRequestToJ
     }
 
     @Override
-    public JSONObject toJSON(OutgoingSearchRequest request, int includedTopGenes)
+    public JSONObject toJSON(String patientId, int includedTopGenes)
     {
-        String patientId = request.getReferencePatientId();
-
         Patient referencePatient = this.getPatientByID(patientId);
         if (referencePatient == null) {
             logger.error("Unable to get patient with id [{}]", patientId);
@@ -85,7 +83,7 @@ public class DefaultOutgoingRequestToJSONConverter implements OutgoingRequestToJ
             }
 
             json.put("id", MD5(patientId));
-            json.put("queryType", request.getQueryType());
+            json.put("queryType", "once");
 
             //JSONObject submitter = new JSONObject();
             //submitter.put("name",  request.getSubmitterName());


### PR DESCRIPTION
Refactored patient->JSON from sending requests and exposed method to see the JSON match request velocity-side. Also removed handling of periodic and async methods.

In terms of refactoring, instead of creating a request for the triple (patientId, remoteServer, api), and then filling in details, it now creates the JSON query separately from just (patientId, api). I exposed this method on the velocity side so that it can be displayed for debugging purposes. I was going to have the send method accept the JSON returned from getResponse(), but decided it would be best to not expose the ability to send arbitrary JSON to MME servers.

Beyond that, a lot of the diff is eclipse reformatting and import organization.

Thoughts?