### PR TITLE
RM-40: include submitter details in the match request/response

### DIFF
--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
@@ -22,6 +22,7 @@ import org.phenotips.data.Disorder;
 import org.phenotips.data.Feature;
 import org.phenotips.data.FeatureMetadatum;
 import org.phenotips.data.Patient;
+import org.phenotips.data.PatientData;
 import org.phenotips.data.similarity.PatientGenotype;
 import org.phenotips.data.similarity.internal.DefaultPatientGenotype;
 import org.phenotips.remote.common.ApplicationConfiguration;
@@ -37,7 +38,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-
+import org.codehaus.plexus.util.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -76,12 +77,7 @@ public class DefaultPatientToJSONConverter implements PatientToJSONConverter
         json.put(ApiConfiguration.JSON_PATIENT_ID, patient.getId());
 
         // TODO
-        JSONObject contactJson = new JSONObject();
-        contactJson.put(ApiConfiguration.JSON_CONTACT_NAME,        "PhenomeCentral");
-        contactJson.put(ApiConfiguration.JSON_CONTACT_INSTITUTION, "PhenomeCentral");
-        contactJson.put(ApiConfiguration.JSON_CONTACT_HREF,        "mailto:matchmaker@phenomecentral.org");
-        json.put(ApiConfiguration.JSON_CONTACT, contactJson);
-
+        json.put(ApiConfiguration.JSON_CONTACT, DefaultPatientToJSONConverter.contact(patient));
         try {
             json.put(ApiConfiguration.JSON_PATIENT_GENDER, DefaultPatientToJSONConverter.gender(patient));
             // TODO
@@ -110,6 +106,30 @@ public class DefaultPatientToJSONConverter implements PatientToJSONConverter
         }
 
         return json;
+    }
+
+    private static JSONObject contact(Patient patient) {
+        // Default contact info
+        String name = "PhenomeCentral";
+        String institution = "PhenomeCentral";
+        String href = "mailto:matchmaker@phenomecentral.org";
+
+        PatientData<String> data = patient.getData("contact");
+        if (data != null && data.isNamed()) {
+            name = data.get("name");
+            institution = data.get("institution");
+            // TODO: replace this with a URL to a match/contact page
+            String email = data.get("email");
+            if (!StringUtils.isBlank(email)) {
+                href = "mailto:" + email;
+            }
+        }
+
+        JSONObject contactJson = new JSONObject();
+        contactJson.put(ApiConfiguration.JSON_CONTACT_NAME, name);
+        contactJson.put(ApiConfiguration.JSON_CONTACT_INSTITUTION, institution);
+        contactJson.put(ApiConfiguration.JSON_CONTACT_HREF, href);
+        return contactJson;
     }
 
     private JSONArray features(Patient patient)

--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.codehaus.plexus.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
@@ -110,13 +110,17 @@ public class DefaultPatientToJSONConverter implements PatientToJSONConverter
 
     private static JSONObject contact(Patient patient) {
         // Default contact info
-        String name = "PhenomeCentral";
+        String name = "PhenomeCentral Support";
         String institution = "PhenomeCentral";
         String href = "mailto:matchmaker@phenomecentral.org";
 
         PatientData<String> data = patient.getData("contact");
         if (data != null && data.isNamed()) {
-            name = data.get("name");
+            String contactName = data.get("name");
+            if (!StringUtils.isBlank(contactName)) {
+                name = contactName;
+            }
+            // Replace institution, even if blank
             institution = data.get("institution");
             // TODO: replace this with a URL to a match/contact page
             String email = data.get("email");
@@ -127,7 +131,10 @@ public class DefaultPatientToJSONConverter implements PatientToJSONConverter
 
         JSONObject contactJson = new JSONObject();
         contactJson.put(ApiConfiguration.JSON_CONTACT_NAME, name);
-        contactJson.put(ApiConfiguration.JSON_CONTACT_INSTITUTION, institution);
+        // Institution is optional, so only include if non-blank
+        if (!StringUtils.isBlank(institution)) {
+            contactJson.put(ApiConfiguration.JSON_CONTACT_INSTITUTION, institution);
+        }
         contactJson.put(ApiConfiguration.JSON_CONTACT_HREF, href);
         return contactJson;
     }


### PR DESCRIPTION
This is a starting point, but shouldn't be merged yet. We need a match page to link to in the contact href instead of a mailto: to their email, since we don't want to disclose the email address.