### PR TITLE
RM-44: Only report candidate genes in matches (not exome data)

### DIFF
--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultPatientToJSONConverter.java
@@ -351,9 +351,12 @@ public class DefaultPatientToJSONConverter implements PatientToJSONConverter
                 JSONObject nextGeneInfo = orderedPatientGenes.optJSONObject(i);
                 // no check for null so that if nextGeneInfo is not a JSONObject an error will be logged
                 String geneName = nextGeneInfo.optString("gene", null);
-                if (geneName != null) {
+                // Only include gene if listed as a candidate (score of 1)
+                double geneScore = nextGeneInfo.optDouble("score", 0.0);
+                if (geneName != null && geneScore >= 1.0) {
                     JSONObject gene = new JSONObject();
                     gene.put(ApiConfiguration.JSON_GENES_GENE_ID, geneName);
+                    // TODO: add gene status (solved/candidate/exome) here
 
                     JSONObject nextGene = new JSONObject();
                     nextGene.put(ApiConfiguration.JSON_GENES_GENE, gene);

--- a/core/server/src/main/java/org/phenotips/remote/server/internal/IncomingSearchRequestProcessor.java
+++ b/core/server/src/main/java/org/phenotips/remote/server/internal/IncomingSearchRequestProcessor.java
@@ -133,11 +133,11 @@ public class IncomingSearchRequestProcessor implements SearchRequestProcessor
         for (PatientSimilarityView match : matches) {
             if (consentManager.hasConsent(match.getId(), "matching")) {
                 // For now, only include results where the genotype score is high enough to indicate a candidate
-                // gene matched (exome data gives max score of 0.5, and candidate genes boost towards 1.0)
+                // gene matched (exome data gives max score of 0.5, and candidate genes have score of 1.0)
                 //
                 // FIXME: once PatientSimilarityView exposes candidate genes, use that to check if candidate genes
                 // matched instead of this indirect test based on the score
-                if (match.getGenotypeScore() > 0.5) {
+                if (match.getGenotypeScore() >= 1.0) {
                     filteredMatches.add(match);
                 }
             } else {


### PR DESCRIPTION
This is a fragile implementation and assumes that candidate genes get a score of 1.0. This needs to be refactored with a reevaluation of the `PatientSimilarityView` interface to expose genomic data.