### PR TITLE
RM-61: If matches are null in DefaultRemoteMatchingService#getSimilar…

### DIFF
--- a/core/client/src/main/java/org/phenotips/remote/client/internal/DefaultRemoteMatchingService.java
+++ b/core/client/src/main/java/org/phenotips/remote/client/internal/DefaultRemoteMatchingService.java
@@ -247,6 +247,7 @@ public class DefaultRemoteMatchingService implements RemoteMatchingService
         JSONArray matches = replyJSON.optJSONArray("results");
         if (matches == null) {
             this.logger.error("No key 'results' in reply JSON");
+            return resultsList;
         }
 
         for (int i = 0; i < matches.length(); ++i) {


### PR DESCRIPTION
…ityResults, an empty list is now returned.