### PR TITLE
RM-92: MME test patients should not be displayed as real matches in matching notification and on the patient page

### DIFF
--- a/core/api/src/main/java/org/phenotips/remote/api/ApiConfiguration.java
+++ b/core/api/src/main/java/org/phenotips/remote/api/ApiConfiguration.java
@@ -62,6 +62,8 @@ public interface ApiConfiguration
 
     String JSON_PATIENT_ID = "id";
 
+    String JSON_PATIENT_TEST = "test";
+
     String JSON_PATIENT_LABEL = "label";
 
     String JSON_PATIENT_GENDER = "sex";

--- a/core/api/src/main/java/org/phenotips/remote/api/IncomingMatchRequest.java
+++ b/core/api/src/main/java/org/phenotips/remote/api/IncomingMatchRequest.java
@@ -23,12 +23,18 @@ import org.phenotips.data.Patient;
 public interface IncomingMatchRequest extends MatchRequest
 {
     /**
-     * @return
+     * @return the model patient stuffed into a Phenotips Patient class
      */
     Patient getModelPatient();
 
     /**
-     * @param response
+     * @param response the raw response sent back to the requesting server as a reply to this incoming request
      */
     void addResponse(JSONObject response);
+
+    /**
+     * @return true iff the model patient is a test patient (and thus resulting matches are not "real"
+     *              and should not be stored and reported to users => request is a "test request")
+     */
+    boolean isTestRequest();
 }

--- a/core/client/src/main/java/org/phenotips/remote/client/internal/DefaultRemoteMatchingService.java
+++ b/core/client/src/main/java/org/phenotips/remote/client/internal/DefaultRemoteMatchingService.java
@@ -264,6 +264,11 @@ public class DefaultRemoteMatchingService implements RemoteMatchingService
                 JSONObject next = matches.getJSONObject(i);
                 JSONObject nextPatient = next.getJSONObject("patient");
 
+                // skip test patients (it seems that API allows mixing real and test patients in the same response)
+                if (nextPatient.optBoolean(ApiConfiguration.JSON_PATIENT_TEST, false)) {
+                    continue;
+                }
+
                 Patient modelRemotePatient = patientConverter.convert(nextPatient);
 
                 double patientScore = 0;

--- a/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultIncomingJSONParser.java
+++ b/core/common/src/main/java/org/phenotips/remote/common/internal/api/DefaultIncomingJSONParser.java
@@ -53,7 +53,8 @@ public class DefaultIncomingJSONParser implements IncomingJSONParser
         Patient requestPatient = this.patientConverter.convert(patientJSON);
 
         DefaultIncomingMatchRequest request =
-            new DefaultIncomingMatchRequest(remoteServerId, this.apiVersion, jsonRequest.toString(), requestPatient);
+            new DefaultIncomingMatchRequest(remoteServerId, this.apiVersion, jsonRequest.toString(),
+                    requestPatient, patientJSON.optBoolean(ApiConfiguration.JSON_PATIENT_TEST, false));
 
         this.logger.debug("JSON->IncomingRequest done");
 

--- a/core/hibernate/src/main/java/org/phenotips/remote/hibernate/internal/DefaultIncomingMatchRequest.java
+++ b/core/hibernate/src/main/java/org/phenotips/remote/hibernate/internal/DefaultIncomingMatchRequest.java
@@ -38,6 +38,9 @@ public class DefaultIncomingMatchRequest extends AbstractSearchRequest implement
     @Transient
     private Patient remotePatient;
 
+    @Transient
+    private boolean isTestRequest;
+
     /**
      * Hibernate requires a no-args constructor
      */
@@ -50,11 +53,12 @@ public class DefaultIncomingMatchRequest extends AbstractSearchRequest implement
      *            be assigned when the request is stored in the database
      */
     public DefaultIncomingMatchRequest(String remoteServerId, String apiVersionUsed,
-        String request, Patient remotePatient)
+        String request, Patient remotePatient, boolean isTestRequest)
     {
         super(remoteServerId, apiVersionUsed, request, null);
 
         this.remotePatient = remotePatient;
+        this.isTestRequest = isTestRequest;
     }
 
     @Override
@@ -63,8 +67,15 @@ public class DefaultIncomingMatchRequest extends AbstractSearchRequest implement
         this.setResponse(response.toString());
     }
 
+    @Override
     public Patient getModelPatient()
     {
         return this.remotePatient;
+    }
+
+    @Override
+    public boolean isTestRequest()
+    {
+        return this.isTestRequest;
     }
 }


### PR DESCRIPTION
@sashaandjic : it is very hard to test the actual functionality (need to manually craft test requests and/or modify code to create a test server that returns test patients as results), but at least need to test that nothing that used o work is broken